### PR TITLE
Add Jenkins label to target intended architecture

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
     agent {
         docker {
             image 'my127/php:7.2-fpm-stretch-console'
+            label 'linux-amd64'
         }
     }
     environment {


### PR DESCRIPTION
This will be needed when Jenkins docker plugin doesn't have a specific base runner label configured, as will pick any runner